### PR TITLE
Working wireframe subsets for patches

### DIFF
--- a/avtopenpmdFileFormat.C
+++ b/avtopenpmdFileFormat.C
@@ -893,6 +893,17 @@ void avtopenpmdFileFormat::PopulateHierarchyCache(
         debug1 << "[openpmd-api-plugin] Cached structured boundaries for mesh '"
                << visitMeshName << "' timeState=" << timeState << "\n";
       }
+
+      avtStructuredDomainNesting *nesting =
+          BuildDomainNesting(cachedHierarchy);
+      if (nesting != nullptr) {
+        void_ref_ptr nestVr(nesting, avtStructuredDomainNesting::Destruct);
+        cache->CacheVoidRef("any_mesh",
+                            AUXILIARY_DATA_DOMAIN_NESTING_INFORMATION,
+                            timeState, -1, nestVr);
+        debug1 << "[openpmd-api-plugin] Cached domain nesting for mesh '"
+               << visitMeshName << "' timeState=" << timeState << "\n";
+      }
     }
 #else
     debug2 << "[openpmd-api-plugin] Skipping structured boundary cache for mesh '"
@@ -918,8 +929,7 @@ void avtopenpmdFileFormat::PopulateHierarchyCache(
       meshMd->groupTitle = "levels";
       meshMd->groupPieceName = "level";
       meshMd->blockNames = hierarchy.blockNames;
-      meshMd->containsGhostZones = AVT_HAS_GHOSTS;
-      meshMd->presentGhostZoneTypes = (1 << AVT_NESTING_GHOST_ZONES);
+      meshMd->containsGhostZones = AVT_NO_GHOSTS;
       md->Add(meshMd);
       md->AddGroupInformation(hierarchy.numLevels,
                               static_cast<int>(hierarchy.patches.size()),
@@ -1397,23 +1407,7 @@ void *avtopenpmdFileFormat::GetAuxiliaryData(const char *var, int timestep,
     return true;
   };
 
-  if (type != nullptr &&
-      strcmp(type, AUXILIARY_DATA_DOMAIN_BOUNDARY_INFORMATION) == 0) {
-    std::string meshNameResolved;
-    const MeshPatchHierarchy *hier = nullptr;
-    if (!resolveMesh(meshNameResolved, hier)) {
-      return NULL;
-    }
-    return avtMTMDFileFormat::GetAuxiliaryData(meshNameResolved.c_str(),
-                                               timestep, domain, type, args,
-                                               df);
-  }
-
   if (type != nullptr) {
-    if (strcmp(type, AUXILIARY_DATA_DOMAIN_BOUNDARY_INFORMATION) == 0) {
-      debug2 << "[openpmd-api-plugin] Delegating domain boundary request to base cache" << "\n";
-      return avtMTMDFileFormat::GetAuxiliaryData(var, timestep, domain, type, args, df);
-    }
     const MeshPatchHierarchy *hierarchyPtr = nullptr;
     std::string meshName;
     auto requireHierarchy = [&]() -> bool {
@@ -1422,6 +1416,23 @@ void *avtopenpmdFileFormat::GetAuxiliaryData(const char *var, int timestep,
       }
       return resolveMesh(meshName, hierarchyPtr);
     };
+
+    if (strcmp(type, AUXILIARY_DATA_DOMAIN_BOUNDARY_INFORMATION) == 0) {
+      if (!requireHierarchy()) {
+        return NULL;
+      }
+      const MeshPatchHierarchy &hierarchy = *hierarchyPtr;
+      debug2 << "[openpmd-api-plugin] Building domain boundary info for mesh '"
+             << meshName << "'\n";
+      avtStructuredDomainBoundaries *dbi =
+          BuildStructuredDomainBoundaries(hierarchy);
+      if (dbi == nullptr) {
+        debug1 << "[openpmd-api-plugin] Domain boundary build returned nullptr\n";
+        return NULL;
+      }
+      df = avtStructuredDomainBoundaries::Destruct;
+      return dbi;
+    }
 
     if (strcmp(type, AUXILIARY_DATA_DOMAIN_NESTING_INFORMATION) == 0) {
       if (!requireHierarchy()) {
@@ -1767,7 +1778,7 @@ MeshPatchHierarchy avtopenpmdFileFormat::CreateHierarchyForGroup(
       patch.storageExtentCanonical = storageExtentCanonical;
 
       openPMD::Offset vtkOffset(3, 0);
-      openPMD::Extent vtkExtent(3, 1);
+      openPMD::Extent vtkExtent(3, 0);
       std::array<int, 3> storageToVtk{{-1, -1, -1}};
       for (size_t axis = 0; axis < 3; ++axis) {
         int storageIndex = -1;
@@ -1804,6 +1815,11 @@ MeshPatchHierarchy avtopenpmdFileFormat::CreateHierarchyForGroup(
       patch.storageToVtk = storageToVtk;
       patch.offset = vtkOffset;
       patch.extent = vtkExtent;
+
+      for (int axis = hierarchy.topologicalDim; axis < 3; ++axis) {
+        patch.extent[axis] = 0;
+        patch.offset[axis] = 0;
+      }
 
       for (int axis = 0; axis < 3; ++axis) {
         double spacing = spacingPerAxis[axis];
@@ -1881,7 +1897,7 @@ avtopenpmdFileFormat::CreateRectilinearPatch(const PatchInfo &patch) const {
 
   for (int axis = 0; axis < 3; ++axis) {
     const uint64_t cells =
-        axis < static_cast<int>(patch.extent.size()) ? patch.extent[axis] : 1;
+        axis < static_cast<int>(patch.extent.size()) ? patch.extent[axis] : 0;
     int nodes = static_cast<int>(cells);
     if (patch.centering == AVT_ZONECENT) {
       nodes = static_cast<int>(cells + 1);
@@ -2142,12 +2158,11 @@ avtopenpmdFileFormat::BuildStructuredDomainBoundaries(
     for (int axis = 0; axis < 3; ++axis) {
       if (axis >= hierarchy.topologicalDim) {
         extents[2 * axis] = 0;
-        extents[2 * axis + 1] = 1;
+        extents[2 * axis + 1] = 0;
         continue;
       }
       extents[2 * axis] = patch.logicalLower[axis];
-      int upperExclusive = patch.logicalUpper[axis] + 1;
-      extents[2 * axis + 1] = upperExclusive;
+      extents[2 * axis + 1] = patch.logicalUpper[axis] + 1;
     }
     debug5 << "[openpmd-api-plugin] StructuredBoundaries patch=" << patchIdx
            << " level=" << (patchIdx < hierarchy.levelIdsPerPatch.size()
@@ -2162,6 +2177,19 @@ avtopenpmdFileFormat::BuildStructuredDomainBoundaries(
     }
     boundaries->SetIndicesForAMRPatch(static_cast<int>(patchIdx), level,
                                       extents);
+  }
+
+  if (hierarchy.numLevels > 1 &&
+      !hierarchy.levelRefinementRatios.empty()) {
+    std::vector<std::vector<int>> refRatios(hierarchy.numLevels,
+                                            std::vector<int>(3, 1));
+    for (int lev = 1; lev < hierarchy.numLevels; ++lev) {
+      if (lev - 1 < static_cast<int>(hierarchy.levelRefinementRatios.size())) {
+        const auto &ratio = hierarchy.levelRefinementRatios[lev - 1];
+        refRatios[lev] = {ratio[0], ratio[1], ratio[2]};
+      }
+    }
+    boundaries->SetRefinementRatios(refRatios);
   }
 
   boundaries->CalculateBoundaries();
@@ -3020,9 +3048,6 @@ vtkDataSet *avtopenpmdFileFormat::GetMesh(int timeState, int domain,
   LogPatchSummary(patch, ctx.str());
 
   vtkDataSet *grid = CreateRectilinearPatch(patch);
-  if (auto *rect = vtkRectilinearGrid::SafeDownCast(grid)) {
-    AddGhostZonesForPatch(hierarchy, domain, rect);
-  }
   debug1 << "[openpmd-api-plugin] GetMesh success mesh='" << meshName
          << "' domain=" << domain << "\n";
   return grid;

--- a/avtopenpmdFileFormat.C
+++ b/avtopenpmdFileFormat.C
@@ -901,6 +901,9 @@ void avtopenpmdFileFormat::PopulateHierarchyCache(
         cache->CacheVoidRef("any_mesh",
                             AUXILIARY_DATA_DOMAIN_NESTING_INFORMATION,
                             timeState, -1, nestVr);
+        cache->CacheVoidRef(visitMeshName.c_str(),
+                            AUXILIARY_DATA_DOMAIN_NESTING_INFORMATION,
+                            timeState, -1, nestVr);
         debug1 << "[openpmd-api-plugin] Cached domain nesting for mesh '"
                << visitMeshName << "' timeState=" << timeState << "\n";
       }
@@ -2181,12 +2184,12 @@ avtopenpmdFileFormat::BuildStructuredDomainBoundaries(
 
   if (hierarchy.numLevels > 1 &&
       !hierarchy.levelRefinementRatios.empty()) {
-    std::vector<std::vector<int>> refRatios(hierarchy.numLevels,
+    std::vector<std::vector<int>> refRatios(hierarchy.numLevels - 1,
                                             std::vector<int>(3, 1));
     for (int lev = 1; lev < hierarchy.numLevels; ++lev) {
       if (lev - 1 < static_cast<int>(hierarchy.levelRefinementRatios.size())) {
         const auto &ratio = hierarchy.levelRefinementRatios[lev - 1];
-        refRatios[lev] = {ratio[0], ratio[1], ratio[2]};
+        refRatios[lev - 1] = {ratio[0], ratio[1], ratio[2]};
       }
     }
     boundaries->SetRefinementRatios(refRatios);


### PR DESCRIPTION
This was all done with Claude:

## Fix AMR Subset wireframe plot for 2D meshes

### Problem

The **Wireframe** checkbox in the Subset plot attributes produced an empty viewport for
AMR meshes read by the openPMD plugin. Surface (filled) mode worked correctly. The issue
affected 2D AMR data completely (blank screen) and would have produced incorrect
double-outlines for 3D AMR data.

### Root causes

**Structural — affected both 2D and 3D:**

- Nesting was never pre-cached at `("any_mesh", NESTING, ts, -1)`, the key VisIt's
  `ApplyGhostForDomainNesting` infrastructure searches. It was only built on demand in
  `GetAuxiliaryData`, which runs too late in the pipeline.
- `containsGhostZones = AVT_HAS_GHOSTS` told VisIt the file already provides ghost zones,
  causing it to skip ghost communication entirely — so VisIt never marked refined cells in
  coarse patches and never created coarse-fine boundary ghost nodes.
- `GetAuxiliaryData` delegated domain boundary info (DBI) to the base class, which couldn't
  find it; the plugin now builds and returns DBI directly.
- `GetMesh` manually called `AddGhostZonesForPatch`, which conflicted with VisIt's automatic
  nesting-based ghost marking.

**2D-specific — caused the completely blank wireframe:**

- For pseudo-2D data stored as 3D chunks (nz=1), `patch.extent[2]` was set to 1 from
  storage rather than being treated as a degenerate axis. Zone-centered: `cells=1 → nodes=2`,
  giving `dims[2]=2`. With nZ=2, `vtkRectilinearGridFacelistFilter` produces a closed box
  where every edge is shared by exactly 2 faces — `vtkVisItFeatureEdges` finds zero boundary
  edges.
- DBI z-extents were `[0,1]` instead of `[0,0]` for 2D patches, causing `ConfirmMesh` to
  reject the DBI once patch dims were corrected.

### Fix

- Cache nesting during `PopulateHierarchyCache` alongside the DBI, so
  `ApplyGhostForDomainNesting` finds it.
- Change `containsGhostZones` to `AVT_NO_GHOSTS` so VisIt runs its full ghost pipeline.
- Build and return DBI directly from `GetAuxiliaryData` instead of delegating to the base
  class.
- Clamp `patch.extent[axis] = 0` for axes beyond `topologicalDim` so 2D patches always
  produce `dims[2]=1` (flat sheet with boundary edges, not a closed box).
- Fix DBI z-extents to `[0,0]` for 2D so `ConfirmMesh` passes after the dims fix.
- Call `SetRefinementRatios` on the DBI so `CalculateBoundaries` correctly identifies
  neighbors across AMR levels.
- Remove the manual `AddGhostZonesForPatch` call from `GetMesh`.

<img width="968" height="850" alt="image" src="https://github.com/user-attachments/assets/2b5e1969-fc2e-40f0-a9a7-dc427ed7461c" />
